### PR TITLE
Local dev/datatables life cycle

### DIFF
--- a/SistemaTurnosOnline.Web/Pages/ListarCarreras/ListarCarrerasBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarCarreras/ListarCarrerasBase.cs
@@ -16,29 +16,36 @@ namespace SistemaTurnosOnline.Web.Pages.ListarCarreras
         [Parameter]
         public string TableId { get; set; } = "carrerasTable";
 
+        private bool listLoaded = false;
+
+        private bool tableInitialized = false;
+
         protected async override Task OnInitializedAsync()
         {
             Carreras = await CarreraService.GetCarreras();
+
+            listLoaded = true;
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (Carreras is not null && !firstRender)
+            if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>(identifier: "datatableInit", "#" + TableId);
-                await base.OnAfterRenderAsync(firstRender);
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
+                tableInitialized = true;
             }
         }
 
+        //https://datatables.net/forums/discussion/56389/datatables-with-blazor
         public async void Dispose()
         {
             try
             {
-                await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
+                if (tableInitialized)
+                    await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
             }
             catch
             {
-
             }
         }
     }

--- a/SistemaTurnosOnline.Web/Pages/ListarCarreras/ListarCarrerasBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarCarreras/ListarCarrerasBase.cs
@@ -31,8 +31,9 @@ namespace SistemaTurnosOnline.Web.Pages.ListarCarreras
         {
             if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
                 tableInitialized = true;
+
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
             }
         }
 

--- a/SistemaTurnosOnline.Web/Pages/ListarProfesores/ListarTodosProfesorBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarProfesores/ListarTodosProfesorBase.cs
@@ -19,9 +19,16 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesores
         public List<string> Headers { get; set; } = new List<string> { "DNI", "Nombre", "Email", "" };
         [Parameter]
         public string TableId { get; set; } = "profesoresTable";
+
+        private bool listLoaded = false;
+
+        private bool tableInitialized = false;
+
         protected override async Task OnInitializedAsync()
         {
             Profesores = (await ProfesorService.GetProfesores()).ToList();
+
+            listLoaded = true;
 
             var authState = await AuthenticationState;
 
@@ -34,10 +41,10 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesores
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (Profesores is not null && !firstRender)
+            if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>(identifier: "datatableInit", "#" + TableId);
-                await base.OnAfterRenderAsync(firstRender);
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
+                tableInitialized = true;
             }
         }
 
@@ -46,11 +53,11 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesores
         {
             try
             {
-                await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
+                if (tableInitialized)
+                    await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
             }
             catch
             {
-
             }
         }
     }

--- a/SistemaTurnosOnline.Web/Pages/ListarProfesores/ListarTodosProfesorBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarProfesores/ListarTodosProfesorBase.cs
@@ -43,8 +43,9 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesores
         {
             if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
                 tableInitialized = true;
+
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
             }
         }
 

--- a/SistemaTurnosOnline.Web/Pages/ListarProfesoresInactivos/ListarProfesoresInactivosBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarProfesoresInactivos/ListarProfesoresInactivosBase.cs
@@ -54,8 +54,9 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesoresInactivos
         {
             if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
                 tableInitialized = true;
+
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
             }
         }
 

--- a/SistemaTurnosOnline.Web/Pages/ListarProfesoresInactivos/ListarProfesoresInactivosBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarProfesoresInactivos/ListarProfesoresInactivosBase.cs
@@ -26,9 +26,15 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesoresInactivos
 
         private HubConnection HubConnection { get; set; }
 
+        private bool listLoaded = false;
+
+        private bool tableInitialized = false;
+
         protected override async Task OnInitializedAsync()
         {
             Profesores = (await ProfesorService.GetProfesoresInactive()).ToList();
+
+            listLoaded = true;
 
             HubConnection = new HubConnectionBuilder().WithUrl(NavigationManager.ToAbsoluteUri("/inactiveUsersHub"))
                 .Build();
@@ -46,28 +52,29 @@ namespace SistemaTurnosOnline.Web.Pages.ListarProfesoresInactivos
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (Profesores is not null && !firstRender)
+            if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>(identifier: "datatableInit", "#" + TableId);
-                await base.OnAfterRenderAsync(firstRender);
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
+                tableInitialized = true;
+            }
+        }
+
+        //https://datatables.net/forums/discussion/56389/datatables-with-blazor
+        public async void Dispose()
+        {
+            try
+            {
+                if (tableInitialized)
+                    await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
+            }
+            catch
+            {
             }
         }
 
         public async ValueTask DisposeAsync()
         {
             await HubConnection.DisposeAsync();
-        }
-
-        public async void Dispose()
-        {
-            try
-            {
-                await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
-            }
-            catch
-            {
-
-            }
         }
     }
 }

--- a/SistemaTurnosOnline.Web/Pages/ListarTurnos/ListarTurnosBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarTurnos/ListarTurnosBase.cs
@@ -66,8 +66,9 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnos
         {
             if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
                 tableInitialized = true;
+
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
             }
         }
 

--- a/SistemaTurnosOnline.Web/Pages/ListarTurnos/ListarTurnosBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarTurnos/ListarTurnosBase.cs
@@ -23,6 +23,10 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnos
         [Parameter]
         public string TableId { get; set; } = "turnosTable";
 
+        private bool listLoaded = false;
+
+        private bool tableInitialized = false;
+
         protected override async Task OnInitializedAsync()
         {
             var turnos = (await TurnoService.GetTurnos()).ToList();
@@ -54,14 +58,16 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnos
             // Se realiza la asignacion aca porque sino se fetchean los datos luego de un OnAfterRenderAsync
             // Por lo tanto, no se debe inicializar la propiedad "TurnoListado" antes del llamado de este metodo
             TurnoListado = turnoListados;
+
+            listLoaded = true;
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (TurnoListado is not null && !firstRender)
+            if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>(identifier: "datatableInit", "#" + TableId);
-                await base.OnAfterRenderAsync(firstRender);
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
+                tableInitialized = true;
             }
         }
 
@@ -70,8 +76,8 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnos
         {
             try
             {
-                await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
-
+                if (tableInitialized)
+                    await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
             }
             catch
             {

--- a/SistemaTurnosOnline.Web/Pages/ListarTurnosUsuario/ListarTurnosUsuarioBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarTurnosUsuario/ListarTurnosUsuarioBase.cs
@@ -159,8 +159,9 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnosUsuario
         {
             if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
                 tableInitialized = true;
+
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
             }
         }
 

--- a/SistemaTurnosOnline.Web/Pages/ListarTurnosUsuario/ListarTurnosUsuarioBase.cs
+++ b/SistemaTurnosOnline.Web/Pages/ListarTurnosUsuario/ListarTurnosUsuarioBase.cs
@@ -62,9 +62,15 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnosUsuario
         public long PosicionEnCola { get; set; }
         public long TurnosRestantes { get; set; }
 
+        private bool listLoaded = false;
+
+        private bool tableInitialized = false;
+
         private async Task GetRemainingTurnsInQueueForUser(string userId)
         {
             Turnos = await TurnoService.GetTurnosByUserId(userId);
+
+            listLoaded = true;
 
             if (Turnos.Count() != 0) PosicionEnCola = Turnos.First().OrdenEnCola;
 
@@ -151,10 +157,10 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnosUsuario
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (Turnos is not null && !firstRender)
+            if (!tableInitialized && listLoaded)
             {
-                await Js.InvokeAsync<object>(identifier: "datatableInit", "#" + TableId);
-                await base.OnAfterRenderAsync(firstRender);
+                await Js.InvokeAsync<object>("datatableInit", "#" + TableId);
+                tableInitialized = true;
             }
         }
 
@@ -163,11 +169,11 @@ namespace SistemaTurnosOnline.Web.Pages.ListarTurnosUsuario
         {
             try
             {
-                await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
+                if (tableInitialized)
+                    await Js.InvokeAsync<object>(identifier: "datatableRemove", "#" + TableId);
             }
             catch
             {
-
             }
         }
 


### PR DESCRIPTION
Se arregla el orden de sentencia en los metodos OnAfterRenderAsync, el cual ahora, cumplida la condicion, realiza un seteo de la flag "tableInitialized" antes de la operacion asincrona de inicializacion de tabla.